### PR TITLE
README.md - amend usage example to something which works

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ Where `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` are replaced with the
 appropriate values from Google that you established in the previous
 step.
 
+## Prerequisites
+
+Besides the Python Google API libraries (see the quickstart guide
+above), if you are using the `-M` option, you will also need the
+`pandoc` executable available and on CLI execution path.
+
+On Debian/Ubuntu, this is available by installing the `pandoc` package.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Synopsis
 
-    gitdriver.py [-h] [--config CONFIG] [--text] [--html] docid
+    gitdriver [-h] [--config CONFIG] [--text] [--html] docid
 
 ## Options
 
@@ -11,7 +11,7 @@
 
 ## Example usage:
 
-    $ python gitdriver.py 1j6Ygv0_this_is_a_fake_document_id_a8Q66mvt4
+    $ python -m gitdriver 1j6Ygv0_this_is_a_fake_document_id_a8Q66mvt4
     Create repository "Untitled"
     Initialized empty Git repository in /home/lars/projects/gitdriver/Untitled/.git/
     [master (root-commit) 27baec9] revision from 2013-01-08T21:57:38.837Z


### PR DESCRIPTION
There are no issues available on this project, so I'll just submit a pull request.

Thanks to larsks for the original code, MartinMensio and the other contributors bringing it up to date for Python 3.

I can confirm this has all worked for me!  The main snag was invoking the script.  The README is unchanged from the original, and the examples don't seem to work as I get this error if try `python gitdrive/gitdrive.py <arguments>`:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "[...]/gitdriver/gitdriver/__main__.py", line 7, in <module>
    from . import gitdriver
ImportError: attempted relative import with no known parent package
```

And this if I try `cd gitdrive; python gitdrive.py <arguments>`:

```
Traceback (most recent call last):
  File "[...]/gitdriver/gitdriver/gitdriver.py", line 13, in <module>
    from . import pandoc_converter
ImportError: attempted relative import with no known parent package
```

I'm not really very familiar with Python, so the answer wasn't obvious to me, but what does seem to work is this, run from the project root:

    python -m gitdriver <arguments>

The README amendments reflect this, although I'm not certain what it should be if the python interpreter isn't used explicitly. And possibly there's a better way - if so please ignore this pull request and document that instead. 

Thanks